### PR TITLE
Update download-params.sh

### DIFF
--- a/scripts/download-params.sh
+++ b/scripts/download-params.sh
@@ -1,3 +1,3 @@
 here=$(dirname $0)
 
-cardano-cli query protocol-parameters --testnet-magic $CARDANO_NODE_MAGIC > ${here}/../assets/pparams.json
+cardano-cli query protocol-parameters --testnet-magic $CARDANO_NODE_MAGIC > ${here}/../assets/params.json


### PR DESCRIPTION
The ReadMe/Guide for the starter project uses "params.json" when building the TX, but the script to download that file saves it as "pparams.json".

Figured to make that edit at the .sh file instead of the readme doc.