### PR TITLE
Updated ReadMe variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ cardano-cli transaction build \
   --tx-in-datum-file assets/lock.datum \
   --tx-in-redeemer-file assets/unlock.redeemer \
   --tx-in-collateral ${collateraltxin} \
-  --change-address $(cat my_address.addr) \
+  --change-address $(cat /assets/wallet1.addr) \
   --protocol-params-file params.json \
   --out-file assets/unlock.tx
 ```
@@ -191,7 +191,7 @@ cardano-cli transaction build \
 ```sh
 cardano-cli transaction sign \
   --tx-body-file assets/unlock.tx \
-  --signing-key-file my_address.skey \
+  --signing-key-file /assets/wallet1.skey \
   --testnet-magic ${CARDANO_NODE_MAGIC} \
   --out-file assets/unlock.tx-signed
 ```


### PR DESCRIPTION
ReadMe says
 "--change-address $(cat my_address.addr) \"
"--signing-key-file my_address.skey \"

BUT 

Internal scripts create: 
"/assets/wallet1.addr"
"/assets/wallet1.skey"

Replaced ReadMe variables with internal script variables