### PR TITLE
Fix mistakes in paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ cardano-cli transaction build \
   --tx-in-redeemer-file assets/unlock.redeemer \
   --tx-in-collateral ${collateraltxin} \
   --change-address $(cat /assets/wallet1.addr) \
-  --protocol-params-file params.json \
+  --protocol-params-file assets/params.json \
   --out-file assets/unlock.tx
 ```
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ cardano-cli transaction build \
   --tx-in-datum-file assets/lock.datum \
   --tx-in-redeemer-file assets/unlock.redeemer \
   --tx-in-collateral ${collateraltxin} \
-  --change-address $(cat /assets/wallet1.addr) \
+  --change-address $(cat assets/wallet1.addr) \
   --protocol-params-file assets/params.json \
   --out-file assets/unlock.tx
 ```
@@ -197,7 +197,7 @@ cardano-cli transaction build \
 ```sh
 cardano-cli transaction sign \
   --tx-body-file assets/unlock.tx \
-  --signing-key-file /assets/wallet1.skey \
+  --signing-key-file assets/wallet1.skey \
   --testnet-magic ${CARDANO_NODE_MAGIC} \
   --out-file assets/unlock.tx-signed
 ```


### PR DESCRIPTION
Mistakes in paths lead to the following errors when executing `cardano-cli` commands:

```
Command failed: transaction build  Error: params.json: params.json: openBinaryFile: does not exist (No such file or directory)
```

```
cat: /assets/wallet1.addr: No such file or directory
```